### PR TITLE
Fix image path handling in post view and template

### DIFF
--- a/app.py
+++ b/app.py
@@ -202,7 +202,7 @@ def view_post(post_id):
             "id": post[0],
             "title": post[1],
             "content": Markup(post[2]),
-            "image": post[3],
+            "image": str(post[3]).replace("static/uploads/", ""),
             "timestamp": formatted_timestamp
         }, dark_mode=True)
     else:

--- a/templates/post.html
+++ b/templates/post.html
@@ -16,7 +16,8 @@
     <p><strong>Published:</strong> {{ post.timestamp }}</p>
     <p>{{ post.content | safe }}</p>
     {% if post.image %}
-        <img src="{{ post.image }}" alt="Post Image" class="image" style="width: 90%;">
+    <img src="{{ url_for('static', filename='uploads/' + post.image) }}" alt="Post Image" class="image" style="width: 90%;">
+
     {% endif %}
     <br>
 </body>


### PR DESCRIPTION
### 🔧🐛 **Fix Image Path Issue in Post View**  

#### 📝 **Description:**  
This PR resolves the issue where post images were not displaying correctly due to an incorrect path. Previously, images were stored with the full `"static/uploads/"` prefix in the database, leading to broken links.  

#### 🔍 **Fix Implemented:**  
✅ **Updated `app.py`:**  
- Removed `"static/uploads/"` from the stored image path to ensure consistency.  
- Used `str(post[3]).replace("static/uploads/", "")` before passing the image name to the template.  

✅ **Updated `templates/post.html`:**  
- Used `url_for('static', filename='uploads/' + post.image)` to correctly reference the image file.  

#### 🛠 **Steps to Test:**  
1️⃣ Upload an image with a new post.  
2️⃣ Open the post and verify that the image **displays correctly**.  
3️⃣ Manually check `http://127.0.0.1:8080/static/uploads/Image.jpg` to confirm accessibility.  

#### 🐛 **Issue Reference:**  
Fixes #3.  